### PR TITLE
[WIP] Add a script to enable building a Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:jessie
+
+COPY cg-fake-uaa /bin
+
+EXPOSE 8080
+
+CMD /bin/cg-fake-uaa

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+set -e
+
+export GOOS=linux
+export GOARCH=amd64
+
+go build
+
+docker build -t cg-fake-uaa:latest .
+
+rm cg-fake-uaa


### PR DESCRIPTION
To build a Docker image, run `./build-docker-image.sh`.  This will create an image with the tag `cg-fake-uaa:latest`.

You can then run the server in Docker by running e.g.:

```
docker run -it --rm -p 8080:8080 cg-fake-uaa
```

Then you can visit `http://localhost:8080/oauth/authorize` and it ought to work.

## Notes

* I wanted to base this off an alpine image, but replacing `debian:jessie` with `alpine:3.5` in the `Dockerfile` results in some weirdness, as running the binary produces a "file not found" error.  I thought this would work since the binary is statically linked, but I guess not.

## To do

- [ ] Make it possible to push this thing out to the ol' Docker Hub.
- [ ] Add instructions to `RELEASE.md` on how to also push the image for the latest release to Docker Hub.

/cc @adelevie 
