### PR TITLE
Add support for refresh_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Change log
+
+All notable changes to this project will be documented in this file,
+which uses the format described in
+[keepachangelog.com](http://keepachangelog.com/). This project adheres
+to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased][unreleased]
+
+* The `/oauth/token` endpoint now supports the `refresh_token` grant
+  type, i.e. the server can now be used to refresh access tokens.
+
+* The `-token-lifetime` command-line argument can be used to specify
+  a lifetime for access tokens, e.g. `10m` or `10s`.
+
+* The example JS client now automatically refreshes the user's access
+  token automatically.
+
+## [1.0.4][] - 2017-03-23
+
+Yet another attempt at rebuilding properly with `goxc`.
+
+## [1.0.3][] - 2017-03-23
+
+Another attempt at rebuilding properly with `goxc`.
+
+## [1.0.2][] - 2017-03-23
+
+No changes to the source--this is just a re-release of 1.0.1, but
+including linux as a build target.
+
+## [1.0.1][] - 2016-07-16
+
+* Show version number on CLI and login page.
+
+## 1.0.0 - 2016-07-16
+
+Initial release.
+
+[unreleased]: https://github.com/18F/cg-fake-uaa/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/18F/cg-fake-uaa/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/18F/cg-fake-uaa/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/18F/cg-fake-uaa/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/18F/cg-fake-uaa/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/18F/cg-fake-uaa/compare/v0.0.1...v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ to [Semantic Versioning](http://semver.org/).
 * The `-token-lifetime` command-line argument can be used to specify
   a lifetime for access tokens, e.g. `10m` or `10s`.
 
-* The example JS client now automatically refreshes the user's access
-  token automatically.
+* The example JS client now refreshes the user's access token automatically.
 
 ## [1.0.4][] - 2017-03-23
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ for the client to work.
 
 The fake server currently has a lot of limitations, most notably:
 
-* The server has no support for refresh tokens.
 * Only the [`openid` scope][] is supported. That is, the server is
   only really built for giving you the logged-in user's email
   address.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,11 @@ Here's how to issue a new release.
    ```
 
 4. Edit `.goxc.json` and increment the `PackageVersion`.
-5. Tag your version and push it to GitHub. For instance, if you're
+5. Update `CHANGELOG.md` by moving the "Unreleased" section to a
+   new section for your new version. Commit the changes with a
+   message like "Bumped version to v1.0.4.". Push your changes to
+   GitHub.
+6. Tag your version and push it to GitHub. For instance, if you're
    releasing v1.0.4, do:
 
    ```
@@ -29,8 +33,8 @@ Here's how to issue a new release.
    git push origin v1.0.4
    ```
 
-6. Run `go generate`.
-7. Run `goxc`.
+7. Run `go generate`.
+8. Run `goxc`.
 
 [goxc]: https://github.com/laher/goxc
 [personal access token]: https://github.com/settings/tokens

--- a/example-client/example-client.js
+++ b/example-client/example-client.js
@@ -26,27 +26,87 @@ const FAKE_STATE = crypto.randomBytes(64).toString('hex');
 
 const app = express();
 
-// Exchanges an authorization code for an authorization token
-function exchangeCodeForAuthToken(code, callback) {
+// A real implementation would use session middleware; because we're
+// an example app, we'll just use a global object.
+let session = {};
+
+// This posts to the token endpoint, either to exchange an authorization
+// code for an access token, or to obtain a new access token from a
+// refresh token (depending on the contents of the given payload).
+//
+// It then sets the session data accordingly: if the token request failed,
+// the user (if any) is logged out. Otherwise, the user is logged in.
+function postToTokenUrl(payload, callback) {
   request.post(UAA_TOKEN_URL, {
-    form: {
-      code,
-      grant_type: 'authorization_code',
-      response_type: 'token',
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
-    },
-  }, callback);
+    form: payload,
+  }, function(err, response, body) {
+    if (!err && response && response.statusCode !== 200) {
+      err = new Error(`got HTTP ${response.statusCode}`);
+    }
+    if (err) {
+      session = {};
+    } else {
+      const responseBody = JSON.parse(body);
+      const decodedToken = jwt.decode(responseBody.access_token);
+
+      Object.assign(session, {
+        email: decodedToken.email,
+        refreshToken: responseBody.refresh_token,
+        expiry: Date.now() + responseBody.expires_in * 1000
+      });
+    }
+    callback(err);
+  });
 }
 
-// Our "home page" contains a login link.
+// This middleware detects if the user's access token has expired; if
+// so, it attempts to renew it with the server. This is primarily a
+// security measure, to ensure that users who lose access to the system
+// are logged out of it ASAP.
+app.use(function tokenRefreshMiddleware(req, res, next) {
+  if (session.expiry && Date.now() > session.expiry) {
+    // Our session has expired! Let's renew it.
+    console.log('User session has expired, attempting to renew it.');
+    postToTokenUrl({
+      grant_type: 'refresh_token',
+      refresh_token: session.refreshToken,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+    }, (err) => {
+      if (err) {
+        console.log('Renewal unsuccessful, user was logged out.');
+      } else {
+        console.log('Renewal successful.');
+      }
+      next();
+    });
+  } else {
+    next();
+  }
+});
+
+// Our "home page".
 app.get('/', (req, res) => {
-  const url = UAA_AUTH_URL + '?' + querystring.stringify({
-    'client_id': CLIENT_ID,
-    'state': FAKE_STATE,
-    'response_type': 'code'
-  });
-  res.send(`<a href="${url}">Log in</a> via <code>${UAA_AUTH_URL}</code>!`);
+  function getLoggedInHtml() {
+    const expiresIn = Math.floor((session.expiry - Date.now()) / 1000);
+    return `
+      <p>Hello ${session.email}!</p>
+      <p>Your access token lasts for another ${expiresIn} seconds,
+      but will be renewed automatically.</p>
+      <p>You can also <a href="/auth/logout">logout</a>.</p>
+    `;
+  }
+
+  function getLoggedOutHtml() {
+    const url = UAA_AUTH_URL + '?' + querystring.stringify({
+      'client_id': CLIENT_ID,
+      'state': FAKE_STATE,
+      'response_type': 'code'
+    });
+    return `<a href="${url}">Log in</a> via <code>${UAA_AUTH_URL}</code>!`;
+  }
+
+  res.send(session.email ? getLoggedInHtml() : getLoggedOutHtml());
 });
 
 // Handler for the registered callback URL.
@@ -61,18 +121,27 @@ app.get('/auth/callback', (req, res) => {
     return;
   }
 
-  exchangeCodeForAuthToken(req.query.code, (err, response, body) => {
+  // This exchanges an authorization code for an authorization token.
+  postToTokenUrl({
+    code: req.query.code,
+    grant_type: 'authorization_code',
+    response_type: 'token',
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+  }, (err) => {
     if (err) {
       res.status(400).send(err);
       return;
     }
 
-    const responseBody = JSON.parse(body);
-    const decodedToken = jwt.decode(responseBody.access_token);
-    const userEmail = decodedToken.email;
-
-    res.send(`Hello, ${userEmail}! You have successfully authenticated.`);
+    res.redirect('/');
   });
+});
+
+// Simple logout view to clear our session.
+app.get('/auth/logout', (req, res) => {
+  session = {};
+  res.redirect('/');
 });
 
 app.listen(PORT, () => {

--- a/example-client/package.json
+++ b/example-client/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC",
+  "license": "CC0-1.0",
   "dependencies": {
     "express": "^4.14.0",
     "jsonwebtoken": "^7.0.1",

--- a/server.go
+++ b/server.go
@@ -9,6 +9,7 @@ import (
 
 type ServerConfig struct {
 	CallbackUrl *url.URL
+	AccessTokenLifetime int64
 }
 
 func NewServerHandler(config *ServerConfig) (func(http.ResponseWriter, *http.Request), error) {
@@ -29,7 +30,7 @@ func baseHandler(config *ServerConfig, w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == Urls.Reverse("authorize") && r.Method == "GET" {
 		Authorize(config, w, r)
 	} else if r.URL.Path == Urls.Reverse("token") && r.Method == "POST" {
-		HandleTokenRequest(w, r)
+		HandleTokenRequest(config, w, r)
 	} else if r.URL.Path == Urls.Reverse("svgLogo") {
 		data := GetAsset("data/fake-cloud.gov.svg")
 		w.Header().Set("Content-Type", "image/svg+xml")

--- a/server.go
+++ b/server.go
@@ -29,7 +29,7 @@ func baseHandler(config *ServerConfig, w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == Urls.Reverse("authorize") && r.Method == "GET" {
 		Authorize(config, w, r)
 	} else if r.URL.Path == Urls.Reverse("token") && r.Method == "POST" {
-		ExchangeCodeForAccessToken(w, r)
+		HandleTokenRequest(w, r)
 	} else if r.URL.Path == Urls.Reverse("svgLogo") {
 		data := GetAsset("data/fake-cloud.gov.svg")
 		w.Header().Set("Content-Type", "image/svg+xml")

--- a/server_test.go
+++ b/server_test.go
@@ -79,6 +79,7 @@ func handle(request *http.Request) *httptest.ResponseRecorder {
 
 	handler, err := NewServerHandler(&ServerConfig{
 		CallbackUrl: Urlify("http://client/callback"),
+		AccessTokenLifetime: 600,
 	})
 
 	if (err != nil)  {

--- a/token.go
+++ b/token.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"github.com/dgrijalva/jwt-go"
 	"net/http"
 	"time"
@@ -17,42 +18,67 @@ type tokenResponse struct {
 	TokenType    string `json:"token_type"`
 }
 
-func ExchangeCodeForAccessToken(w http.ResponseWriter, r *http.Request) {
-	errBadRequest := func(message string) {
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(400)
-		w.Write([]byte(message))
-	}
+func SendBadRequest(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(400)
+	w.Write([]byte(message))
+}
 
-	email := r.PostFormValue("code")
+func HandleTokenRequest(w http.ResponseWriter, r *http.Request) {
 	clientId := r.PostFormValue("client_id")
-
-	if email == "" {
-		errBadRequest("'code' is missing or empty")
-		return
-	}
+	grant_type := r.PostFormValue("grant_type")
 
 	if clientId == "" {
-		errBadRequest("'client_id' is missing or empty")
+		SendBadRequest(w, "'client_id' is missing or empty")
 		return
 	}
 
 	if r.PostFormValue("client_secret") == "" {
-		errBadRequest("'client_secret' is missing or empty")
+		SendBadRequest(w, "'client_secret' is missing or empty")
 		return
 	}
 
-	if r.PostFormValue("grant_type") != "authorization_code" {
-		errBadRequest("'grant_type' is expected to be 'authorization_code'")
+	if grant_type == "authorization_code" {
+		ExchangeCodeForAccessToken(w, r, clientId)
+	} else if grant_type == "refresh_token" {
+		RefreshAccessToken(w, r, clientId)
+	} else {
+		SendBadRequest(w, "'grant_type' must be 'authorization_code' or 'refresh_token'")
+	}
+}
+
+func RefreshAccessToken(w http.ResponseWriter, r *http.Request, clientId string) {
+	refresh_token := r.PostFormValue("refresh_token")
+	parts := strings.SplitN(refresh_token, ":", 2)
+
+	if (parts[0] != "fake_oauth2_refresh_token") {
+		SendBadRequest(w, "'refresh_token' is missing or malformed")
+		return
+	}
+
+	email := parts[1]
+
+	SendAccessToken(w, clientId, email)
+}
+
+func ExchangeCodeForAccessToken(w http.ResponseWriter, r *http.Request, clientId string) {
+	email := r.PostFormValue("code")
+
+	if email == "" {
+		SendBadRequest(w, "'code' is missing or empty")
 		return
 	}
 
 	if r.PostFormValue("response_type") != "token" {
-		errBadRequest("'response_type' is expected to be 'token'")
+		SendBadRequest(w, "'response_type' is expected to be 'token'")
 		return
 	}
 
-	tokenDuration, err := time.ParseDuration("12h")
+	SendAccessToken(w, clientId, email)
+}
+
+func SendAccessToken(w http.ResponseWriter, clientId string, email string) {
+	tokenDuration, err := time.ParseDuration("10m")
 	if err != nil {
 		panic("Unable to parse duration!")
 	}
@@ -101,7 +127,7 @@ func ExchangeCodeForAccessToken(w http.ResponseWriter, r *http.Request) {
 		AccessToken:  accessTokenString,
 		ExpiresIn:    tokenDurationSeconds,
 		Jti:          "fake_jti",
-		RefreshToken: "fake_oauth2_refresh_token",
+		RefreshToken: fmt.Sprintf("fake_oauth2_refresh_token:%s", email),
 		Scope:        "openid",
 		TokenType:    "bearer",
 	})


### PR DESCRIPTION
This fixes #15.

To do:

- [x] Make the example client refresh tokens.
- [x] Make `TestRefreshAccessTokenWorks` and `TestExchangeCodeForAccessTokenWorks` examine the response and verify it looks OK.
